### PR TITLE
Add `#[multiline]` attribute

### DIFF
--- a/crates/gramatika-macro/src/common.rs
+++ b/crates/gramatika-macro/src/common.rs
@@ -75,12 +75,14 @@ pub struct VariantAttrs {
 	pub subset: Option<Ident>,
 	pub patterns: Vec<Literal>,
 	pub discard: bool,
+	pub multiline: bool,
 }
 
 pub fn extract_variant_attrs(variant: &Variant) -> VariantAttrs {
 	let mut subset = None;
 	let mut patterns = vec![];
 	let mut discard = false;
+	let mut multiline = false;
 
 	for attr in variant.attrs.iter() {
 		match attr.path.get_ident() {
@@ -102,6 +104,9 @@ pub fn extract_variant_attrs(variant: &Variant) -> VariantAttrs {
 					_ => None,
 				});
 			}
+			Some(ident) if ident == "multiline" => {
+				multiline = true;
+			}
 			Some(ident) if ident == "discard" => {
 				discard = true;
 			}
@@ -113,6 +118,7 @@ pub fn extract_variant_attrs(variant: &Variant) -> VariantAttrs {
 		subset,
 		patterns,
 		discard,
+		multiline,
 	}
 }
 

--- a/crates/gramatika-macro/src/lexer.rs
+++ b/crates/gramatika-macro/src/lexer.rs
@@ -79,7 +79,26 @@ pub fn derive(input: TokenStream) -> TokenStream {
 						),*};
 						let lexeme = self.remaining.substr(start..end);
 
-						self.lookahead.character += end;
+						if #kind_ident::multilines().contains(&kind) {
+							let mut line_inc = 0_usize;
+							let mut remaining = lexeme.as_str();
+
+							while let Some(idx) = remaining.find('\n') {
+								line_inc += 1;
+								remaining = &remaining[idx+1..];
+							}
+							let char_inc = remaining.len();
+
+							self.lookahead.line += line_inc;
+
+							if line_inc > 0 {
+								self.lookahead.character = char_inc;
+							} else {
+								self.lookahead.character += char_inc;
+							}
+						} else {
+							self.lookahead.character += end;
+						}
 
 						let span = ::gramatika::Span {
 							start: self.current,

--- a/crates/gramatika-macro/src/lib.rs
+++ b/crates/gramatika-macro/src/lib.rs
@@ -7,7 +7,7 @@ mod regex;
 mod token;
 mod traversal;
 
-#[proc_macro_derive(Token, attributes(pattern, subset_of, discard))]
+#[proc_macro_derive(Token, attributes(pattern, subset_of, discard, multiline))]
 pub fn derive_token(input: TokenStream) -> TokenStream {
 	token::derive(input)
 }

--- a/examples/lox/src/tests/lexer.rs
+++ b/examples/lox/src/tests/lexer.rs
@@ -55,6 +55,32 @@ var bar = foo + foo;
 }
 
 #[test]
+fn multi_line_token() {
+	use self::Token::*;
+
+	let input = "
+/**
+ * Here's a block comment!
+ */
+var foo = 2 + 2;
+	";
+	let mut lexer = Lexer::new(input.into());
+	let tokens = lexer.scan();
+
+	let expected = vec![
+		Keyword("var".into(), span![4:0...4:3]),
+		Ident("foo".into(), span![4:4...4:7]),
+		Operator("=".into(), span![4:8...4:9]),
+		NumLit("2".into(), span![4:10...4:11]),
+		Operator("+".into(), span![4:12...4:13]),
+		NumLit("2".into(), span![4:14...4:15]),
+		Punct(";".into(), span![4:15...4:16]),
+	];
+
+	assert_eq!(tokens, expected);
+}
+
+#[test]
 fn ident_with_digit() {
 	let input = "foo2";
 	let mut lexer = Lexer::new(ArcStr::from(input));

--- a/examples/lox/src/tokens.rs
+++ b/examples/lox/src/tokens.rs
@@ -4,6 +4,15 @@ use gramatika::{DebugLisp, Span, Substr, Token as _};
 
 #[derive(DebugLispToken, PartialEq, Token, Lexer)]
 pub enum Token {
+	#[discard]
+	#[pattern = "//.*"]
+	LineComment(Substr, Span),
+
+	#[discard]
+	#[multiline]
+	#[pattern = r"/\*.*?\*/"]
+	BlockComment(Substr, Span),
+
 	#[subset_of(Ident)]
 	#[pattern = "and|class|else|false|for|fun|if|nil|or|print|return|super|this|true|var|while"]
 	Keyword(Substr, Span),

--- a/examples/lox_manual_impl/src/expr.rs
+++ b/examples/lox_manual_impl/src/expr.rs
@@ -279,7 +279,7 @@ impl RecursiveDescent for ParseStream {
 		match self.next() {
 			Some(token) => match token.as_matchable() {
 				(NumLit | StrLit, _, _) => Ok(Expr::Literal(token)),
-				(Keyword, "true" | "false" | "nul", _) => Ok(Expr::Literal(token)),
+				(Keyword, "true" | "false" | "nil", _) => Ok(Expr::Literal(token)),
 				(Keyword, "super", _) => {
 					self.consume(punct![.])?;
 					let method = self.consume_kind(TokenKind::Ident)?;

--- a/examples/lox_manual_impl/src/tests/lexer.rs
+++ b/examples/lox_manual_impl/src/tests/lexer.rs
@@ -57,6 +57,30 @@ var bar = foo + foo;
 }
 
 #[test]
+fn multi_line_token() {
+	let input = "
+/**
+ * Here's a block comment!
+ */
+var foo = 2 + 2;
+	";
+	let mut lexer = Lexer::new(input.into());
+	let tokens = lexer.scan();
+
+	let expected = vec![
+		Token::Keyword("var".into(), span![4:0...4:3]),
+		Token::Ident("foo".into(), span![4:4...4:7]),
+		Token::Operator("=".into(), span![4:8...4:9]),
+		Token::NumLit("2".into(), span![4:10...4:11]),
+		Token::Operator("+".into(), span![4:12...4:13]),
+		Token::NumLit("2".into(), span![4:14...4:15]),
+		Token::Punct(";".into(), span![4:15...4:16]),
+	];
+
+	assert_eq!(tokens, expected);
+}
+
+#[test]
 fn ident_with_digit() {
 	let input = "foo2";
 	let mut lexer = Lexer::new(input.into());


### PR DESCRIPTION
This PR introduces a new `#[multiline]` attribute to configure a token variant's `pattern` to include newline characters when matching `.`. This can be used to tokenize C-style block comments while keeping accurate spans.