### PR TITLE
Update `span!` macro and `Debug` implementation

### DIFF
--- a/crates/gramatika-macro/tests/debug_lisp.rs
+++ b/crates/gramatika-macro/tests/debug_lisp.rs
@@ -122,14 +122,14 @@ fn main() {
 	let ast = Program {
 		exprs: vec![Expr::Binary(BinaryExpr {
 			lhs: Box::new(Expr::Primary(PrimaryExpr {
-				token: Token::Literal("3".into(), span![0:0...0:1]),
+				token: Token::Literal("3".into(), span![1:1..1:2]),
 				maybe: None,
 			})),
-			op: Token::Operator("+".into(), span![0:2...0:3]),
+			op: Token::Operator("+".into(), span![1:3..1:4]),
 			rhs: Box::new(Expr::Unary(UnaryExpr {
-				op: Token::Operator("-".into(), span![0:4...0:5]),
+				op: Token::Operator("-".into(), span![1:5..1:6]),
 				rhs: Box::new(Expr::Primary(PrimaryExpr {
-					token: Token::Literal("2".into(), span![0:5...0:6]),
+					token: Token::Literal("2".into(), span![1:6..1:7]),
 					maybe: None,
 				})),
 			})),
@@ -142,13 +142,13 @@ fn main() {
   exprs: [
     (Expr::Binary (BinaryExpr
       lhs: (Expr::Primary (PrimaryExpr
-        token: `3` (Literal (1:1...1:2)),
+        token: `3` (Literal (1:1..1:2)),
       )),
-      op: `+` (Operator (1:3...1:4)),
+      op: `+` (Operator (1:3..1:4)),
       rhs: (Expr::Unary (UnaryExpr
-        op: `-` (Operator (1:5...1:6)),
+        op: `-` (Operator (1:5..1:6)),
         rhs: (Expr::Primary (PrimaryExpr
-          token: `2` (Literal (1:6...1:7)),
+          token: `2` (Literal (1:6..1:7)),
         )),
       )),
     )),

--- a/crates/gramatika-macro/tests/lexer.rs
+++ b/crates/gramatika-macro/tests/lexer.rs
@@ -128,13 +128,13 @@ fn main() {
 	let tokens = lexer.scan();
 
 	let expected = vec![
-		Token::keyword("let".into(), span![0:0...0:3]),
-		Token::override_test("foo".into(), span![0:4...0:7]),
-		Token::operator("=".into(), span![0:8...0:9]),
-		Token::literal("2".into(), span![0:10...0:11]),
-		Token::operator("+".into(), span![0:12...0:13]),
-		Token::literal("2".into(), span![0:14...0:15]),
-		Token::punct(";".into(), span![0:15...0:16]),
+		Token::keyword("let".into(), span![1:1..1:4]),
+		Token::override_test("foo".into(), span![1:5..1:8]),
+		Token::operator("=".into(), span![1:9..1:10]),
+		Token::literal("2".into(), span![1:11..1:12]),
+		Token::operator("+".into(), span![1:13..1:14]),
+		Token::literal("2".into(), span![1:15..1:16]),
+		Token::punct(";".into(), span![1:16..1:17]),
 	];
 
 	assert_eq!(tokens, expected);

--- a/crates/gramatika-macro/tests/token.rs
+++ b/crates/gramatika-macro/tests/token.rs
@@ -16,50 +16,50 @@ enum Token {
 fn main() {
 	// Constructor functions
 	assert_eq!(
-		Token::keyword("let".into(), span![0:0...0:3]),
-		Token::Keyword("let".into(), span![0:0...0:3]),
+		Token::keyword("let".into(), span![1:1..1:4]),
+		Token::Keyword("let".into(), span![1:1..1:4]),
 	);
 	assert_eq!(
-		Token::ident("foo".into(), span![0:0...0:3]),
-		Token::Ident("foo".into(), span![0:0...0:3]),
+		Token::ident("foo".into(), span![1:1..1:4]),
+		Token::Ident("foo".into(), span![1:1..1:4]),
 	);
 	assert_eq!(
-		Token::punct(";".into(), span![0:0...0:1]),
-		Token::Punct(";".into(), span![0:0...0:1]),
+		Token::punct(";".into(), span![1:1..1:2]),
+		Token::Punct(";".into(), span![1:1..1:2]),
 	);
 	assert_eq!(
-		Token::operator("*".into(), span![0:0...0:1]),
-		Token::Operator("*".into(), span![0:0...0:1]),
+		Token::operator("*".into(), span![1:1..1:2]),
+		Token::Operator("*".into(), span![1:1..1:2]),
 	);
 	assert_eq!(
-		Token::literal("42".into(), span![0:0...0:2]),
-		Token::Literal("42".into(), span![0:0...0:2]),
+		Token::literal("42".into(), span![1:1..1:3]),
+		Token::Literal("42".into(), span![1:1..1:3]),
 	);
 
 	// Macros
 	#[rustfmt::skip]
 	assert_eq!(
 		keyword![let],
-		Token::Keyword("let".into(), span![0:0...0:0]),
+		Token::Keyword("let".into(), span![1:1..1:1]),
 	);
 	#[rustfmt::skip]
 	assert_eq!(
 		ident![foo],
-		Token::Ident("foo".into(), span![0:0...0:0]),
+		Token::Ident("foo".into(), span![1:1..1:1]),
 	);
 	#[rustfmt::skip]
 	assert_eq!(
 		punct![;],
-		Token::Punct(";".into(), span![0:0...0:0]),
+		Token::Punct(";".into(), span![1:1..1:1]),
 	);
 	#[rustfmt::skip]
 	assert_eq!(
 		operator![*],
-		Token::Operator("*".into(), span![0:0...0:0]),
+		Token::Operator("*".into(), span![1:1..1:1]),
 	);
 	#[rustfmt::skip]
 	assert_eq!(
 		literal!["42"],
-		Token::Literal("42".into(), span![0:0...0:0]),
+		Token::Literal("42".into(), span![1:1..1:1]),
 	);
 }

--- a/crates/gramatika/src/parse.rs
+++ b/crates/gramatika/src/parse.rs
@@ -187,13 +187,13 @@ where
 	/// let input = "ab";
 	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
 	///
-	/// assert_eq!(parser.peek(), Some(&Token::Ab("ab".into(), span![0:0...0:2])));
+	/// assert_eq!(parser.peek(), Some(&Token::Ab("ab".into(), span![1:1..1:3])));
 	///
 	/// let a = parser.split_next(1, (Token::a, Token::b)).unwrap();
 	/// let b = parser.next().unwrap();
 	///
-	/// assert_eq!(a, Token::A("a".into(), span![0:0...0:1]));
-	/// assert_eq!(b, Token::B("b".into(), span![0:1...0:2]));
+	/// assert_eq!(a, Token::A("a".into(), span![1:1..1:2]));
+	/// assert_eq!(b, Token::B("b".into(), span![1:2..1:3]));
 	///
 	/// # }
 	/// ```

--- a/crates/gramatika/src/span.rs
+++ b/crates/gramatika/src/span.rs
@@ -44,16 +44,34 @@ pub trait Spanned {
 	fn span(&self) -> Span;
 }
 
+#[doc(hidden)]
+#[macro_export]
+#[deprecated(
+	since = "0.5.0",
+	note = "\n\
+	The `span!` macro signature with three dots and zero-based indices has \
+	been deprecated.\n\n\
+	Use the new signature instead, with two dots and one-based indices:\n\
+	- Old: `span!(0:0...0:4)`\n\
+	- New: `span!(1:1..1:5)`\n\n\
+	See here for more info: https://github.com/dannymcgee/gramatika/pull/5"
+)]
+macro_rules! __span_deprecated {
+	($start_line:literal:$start_char:literal...$end_line:literal:$end_char:literal) => {
+		$crate::Span::new(($start_line, $start_char), ($end_line, $end_char))
+	};
+}
+
 #[macro_export]
 macro_rules! span {
-	($start_line:literal:$start_char:literal...$end_line:literal:$end_char:literal) => {
-		::gramatika::Span::new(($start_line, $start_char), ($end_line, $end_char))
-	};
 	($start_line:literal : $start_char:literal .. $end_line:literal : $end_char:literal) => {
 		::gramatika::Span::new(
 			($start_line - 1, $start_char - 1),
 			($end_line - 1, $end_char - 1),
 		)
+	};
+	($start_line:literal:$start_char:literal...$end_line:literal:$end_char:literal) => {
+		$crate::__span_deprecated!($start_line:$start_char...$end_line:$end_char)
 	};
 }
 

--- a/crates/gramatika/src/span.rs
+++ b/crates/gramatika/src/span.rs
@@ -49,6 +49,12 @@ macro_rules! span {
 	($start_line:literal:$start_char:literal...$end_line:literal:$end_char:literal) => {
 		::gramatika::Span::new(($start_line, $start_char), ($end_line, $end_char))
 	};
+	($start_line:literal : $start_char:literal .. $end_line:literal : $end_char:literal) => {
+		::gramatika::Span::new(
+			($start_line - 1, $start_char - 1),
+			($end_line - 1, $end_char - 1),
+		)
+	};
 }
 
 impl Span {
@@ -79,7 +85,7 @@ impl Span {
 
 impl fmt::Debug for Span {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{:?}...{:?}", self.start, self.end)
+		write!(f, "{:?}..{:?}", self.start, self.end)
 	}
 }
 

--- a/examples/lox/src/tests/lexer.rs
+++ b/examples/lox/src/tests/lexer.rs
@@ -10,13 +10,13 @@ fn it_works() {
 	let tokens = lexer.scan();
 
 	let expected = vec![
-		Keyword(literal_substr!("var"), span![0:0...0:3]),
-		Ident(literal_substr!("foo"), span![0:4...0:7]),
-		Operator(literal_substr!("="), span![0:8...0:9]),
-		NumLit(literal_substr!("2"), span![0:10...0:11]),
-		Operator(literal_substr!("+"), span![0:12...0:13]),
-		NumLit(literal_substr!("2"), span![0:14...0:15]),
-		Punct(literal_substr!(";"), span![0:15...0:16]),
+		Keyword(literal_substr!("var"), span![1:1..1:4]),
+		Ident(literal_substr!("foo"), span![1:5..1:8]),
+		Operator(literal_substr!("="), span![1:9..1:10]),
+		NumLit(literal_substr!("2"), span![1:11..1:12]),
+		Operator(literal_substr!("+"), span![1:13..1:14]),
+		NumLit(literal_substr!("2"), span![1:15..1:16]),
+		Punct(literal_substr!(";"), span![1:16..1:17]),
 	];
 
 	assert_eq!(tokens, expected);
@@ -34,21 +34,21 @@ var bar = foo + foo;
 	let tokens = lexer.scan();
 
 	let expected = vec![
-		Keyword(literal_substr!("var"), span![1:0...1:3]),
-		Ident(literal_substr!("foo"), span![1:4...1:7]),
-		Operator(literal_substr!("="), span![1:8...1:9]),
-		NumLit(literal_substr!("2"), span![1:10...1:11]),
-		Operator(literal_substr!("+"), span![1:12...1:13]),
-		NumLit(literal_substr!("2"), span![1:14...1:15]),
-		Punct(literal_substr!(";"), span![1:15...1:16]),
+		Keyword(literal_substr!("var"), span![2:1..2:4]),
+		Ident(literal_substr!("foo"), span![2:5..2:8]),
+		Operator(literal_substr!("="), span![2:9..2:10]),
+		NumLit(literal_substr!("2"), span![2:11..2:12]),
+		Operator(literal_substr!("+"), span![2:13..2:14]),
+		NumLit(literal_substr!("2"), span![2:15..2:16]),
+		Punct(literal_substr!(";"), span![2:16..2:17]),
 		// ...
-		Keyword(literal_substr!("var"), span![2:0...2:3]),
-		Ident(literal_substr!("bar"), span![2:4...2:7]),
-		Operator(literal_substr!("="), span![2:8...2:9]),
-		Ident(literal_substr!("foo"), span![2:10...2:13]),
-		Operator(literal_substr!("+"), span![2:14...2:15]),
-		Ident(literal_substr!("foo"), span![2:16...2:19]),
-		Punct(literal_substr!(";"), span![2:19...2:20]),
+		Keyword(literal_substr!("var"), span![3:1..3:4]),
+		Ident(literal_substr!("bar"), span![3:5..3:8]),
+		Operator(literal_substr!("="), span![3:9..3:10]),
+		Ident(literal_substr!("foo"), span![3:11..3:14]),
+		Operator(literal_substr!("+"), span![3:15..3:16]),
+		Ident(literal_substr!("foo"), span![3:17..3:20]),
+		Punct(literal_substr!(";"), span![3:20..3:21]),
 	];
 
 	assert_eq!(tokens, expected);
@@ -68,13 +68,13 @@ var foo = 2 + 2;
 	let tokens = lexer.scan();
 
 	let expected = vec![
-		Keyword("var".into(), span![4:0...4:3]),
-		Ident("foo".into(), span![4:4...4:7]),
-		Operator("=".into(), span![4:8...4:9]),
-		NumLit("2".into(), span![4:10...4:11]),
-		Operator("+".into(), span![4:12...4:13]),
-		NumLit("2".into(), span![4:14...4:15]),
-		Punct(";".into(), span![4:15...4:16]),
+		Keyword(literal_substr!("var"), span![5:1..5:4]),
+		Ident(literal_substr!("foo"), span![5:5..5:8]),
+		Operator(literal_substr!("="), span![5:9..5:10]),
+		NumLit(literal_substr!("2"), span![5:11..5:12]),
+		Operator(literal_substr!("+"), span![5:13..5:14]),
+		NumLit(literal_substr!("2"), span![5:15..5:16]),
+		Punct(literal_substr!(";"), span![5:16..5:17]),
 	];
 
 	assert_eq!(tokens, expected);
@@ -88,6 +88,6 @@ fn ident_with_digit() {
 
 	assert_eq!(
 		tokens,
-		vec![Token::Ident(literal_substr!("foo2"), span![0:0...0:4])]
+		vec![Token::Ident(literal_substr!("foo2"), span![1:1..1:5])]
 	);
 }

--- a/examples/lox_manual_impl/src/tests/lexer.rs
+++ b/examples/lox_manual_impl/src/tests/lexer.rs
@@ -2,8 +2,11 @@ use crate::{lexer::Lexer, tokens::Token};
 use gramatika::Lexer as _;
 
 macro_rules! span {
-	($start_line:literal:$start_char:literal...$end_line:literal:$end_char:literal) => {
-		::gramatika::Span::new(($start_line, $start_char), ($end_line, $end_char))
+	($start_line:literal:$start_char:literal..$end_line:literal:$end_char:literal) => {
+		::gramatika::Span::new(
+			($start_line - 1, $start_char - 1),
+			($end_line - 1, $end_char - 1),
+		)
 	};
 }
 
@@ -14,13 +17,13 @@ fn it_works() {
 	let tokens = lexer.scan();
 
 	let expected = vec![
-		Token::Keyword("var".into(), span![0:0...0:3]),
-		Token::Ident("foo".into(), span![0:4...0:7]),
-		Token::Operator("=".into(), span![0:8...0:9]),
-		Token::NumLit("2".into(), span![0:10...0:11]),
-		Token::Operator("+".into(), span![0:12...0:13]),
-		Token::NumLit("2".into(), span![0:14...0:15]),
-		Token::Punct(";".into(), span![0:15...0:16]),
+		Token::Keyword("var".into(), span![1:1..1:4]),
+		Token::Ident("foo".into(), span![1:5..1:8]),
+		Token::Operator("=".into(), span![1:9..1:10]),
+		Token::NumLit("2".into(), span![1:11..1:12]),
+		Token::Operator("+".into(), span![1:13..1:14]),
+		Token::NumLit("2".into(), span![1:15..1:16]),
+		Token::Punct(";".into(), span![1:16..1:17]),
 	];
 
 	assert_eq!(tokens, expected);
@@ -36,21 +39,21 @@ var bar = foo + foo;
 	let tokens = lexer.scan();
 
 	let expected = vec![
-		Token::Keyword("var".into(), span![1:0...1:3]),
-		Token::Ident("foo".into(), span![1:4...1:7]),
-		Token::Operator("=".into(), span![1:8...1:9]),
-		Token::NumLit("2".into(), span![1:10...1:11]),
-		Token::Operator("+".into(), span![1:12...1:13]),
-		Token::NumLit("2".into(), span![1:14...1:15]),
-		Token::Punct(";".into(), span![1:15...1:16]),
+		Token::Keyword("var".into(), span![2:1..2:4]),
+		Token::Ident("foo".into(), span![2:5..2:8]),
+		Token::Operator("=".into(), span![2:9..2:10]),
+		Token::NumLit("2".into(), span![2:11..2:12]),
+		Token::Operator("+".into(), span![2:13..2:14]),
+		Token::NumLit("2".into(), span![2:15..2:16]),
+		Token::Punct(";".into(), span![2:16..2:17]),
 		// ...
-		Token::Keyword("var".into(), span![2:0...2:3]),
-		Token::Ident("bar".into(), span![2:4...2:7]),
-		Token::Operator("=".into(), span![2:8...2:9]),
-		Token::Ident("foo".into(), span![2:10...2:13]),
-		Token::Operator("+".into(), span![2:14...2:15]),
-		Token::Ident("foo".into(), span![2:16...2:19]),
-		Token::Punct(";".into(), span![2:19...2:20]),
+		Token::Keyword("var".into(), span![3:1..3:4]),
+		Token::Ident("bar".into(), span![3:5..3:8]),
+		Token::Operator("=".into(), span![3:9..3:10]),
+		Token::Ident("foo".into(), span![3:11..3:14]),
+		Token::Operator("+".into(), span![3:15..3:16]),
+		Token::Ident("foo".into(), span![3:17..3:20]),
+		Token::Punct(";".into(), span![3:20..3:21]),
 	];
 
 	assert_eq!(tokens, expected);
@@ -68,13 +71,13 @@ var foo = 2 + 2;
 	let tokens = lexer.scan();
 
 	let expected = vec![
-		Token::Keyword("var".into(), span![4:0...4:3]),
-		Token::Ident("foo".into(), span![4:4...4:7]),
-		Token::Operator("=".into(), span![4:8...4:9]),
-		Token::NumLit("2".into(), span![4:10...4:11]),
-		Token::Operator("+".into(), span![4:12...4:13]),
-		Token::NumLit("2".into(), span![4:14...4:15]),
-		Token::Punct(";".into(), span![4:15...4:16]),
+		Token::Keyword("var".into(), span![5:1..5:4]),
+		Token::Ident("foo".into(), span![5:5..5:8]),
+		Token::Operator("=".into(), span![5:9..5:10]),
+		Token::NumLit("2".into(), span![5:11..5:12]),
+		Token::Operator("+".into(), span![5:13..5:14]),
+		Token::NumLit("2".into(), span![5:15..5:16]),
+		Token::Punct(";".into(), span![5:16..5:17]),
 	];
 
 	assert_eq!(tokens, expected);
@@ -86,5 +89,5 @@ fn ident_with_digit() {
 	let mut lexer = Lexer::new(input.into());
 	let tokens = lexer.scan();
 
-	assert_eq!(tokens, vec![Token::Ident("foo2".into(), span![0:0...0:4])]);
+	assert_eq!(tokens, vec![Token::Ident("foo2".into(), span![1:1..1:5])]);
 }


### PR DESCRIPTION
Previously, the `Span` type had a manual `Debug` implementation that looked like this:

```rs
let some_span = Span::new((0, 0), (0, 3))
println!("{some_span:?}"); // => (1:1...1:4)
```

All the numeric values are incremented to better match what you would see in your IDE for the line/column number at a given cursor position.

This crate also exports a `span!` macro, which you might expect to behave the same way, given the similar syntax... but it didn't:

```rs
let some_span = span!(1:1...1:4);
println!("{some_span:?}"); // => (2:2...2:5)
```

Additionally, the triple-dot ellipses `...` are a little problematic, because what the span actually represents is an _exclusive_ range, which would be expressed in Rust with two dots: `x..y`.

Both of these issues have now been addressed. Debugging a `Span` prints the output with two dots:

```rs
let some_span = Span::new((0, 0), (0, 3))
println!("{some_span:?}"); // => (1:1..1:4)
```

And the `span!` macro has a new signature expecting two dots and 1-based indices:

```rs
let some_span = span!(1:1..1:4);
println!("{some_span:?}"); // => (1:1..1:4)
```

The `span!` macro is mostly useful for unit-testing, as there's little other reason to manually construct a span out of literals like this, so my hope is that this will make it easier to unit test against actual source files, where you'll likely be looking up the actual spans of particular symbols by looking at the line and column numbers in your editor.

But just in case, this PR _also_ leaves the old `span!` signature in place, with triple-dot ellipses and 0-based indices, for the sake of backwards compatibility.