### PR TITLE
Fix lost tokens on conversion failure

### DIFF
--- a/crates/gramatika/Cargo.toml
+++ b/crates/gramatika/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gramatika"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["Danny McGee <dannymcgee@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/crates/gramatika/src/parse.rs
+++ b/crates/gramatika/src/parse.rs
@@ -912,10 +912,13 @@ where
 
 					Some(Ok(converted))
 				} else {
+					let span = token.span();
+					self.tokens.push(token);
+
 					Some(Err(SpannedError {
 						message: format!("Expected {:?}", kind),
 						source: self.source(),
-						span: Some(token.span()),
+						span: Some(span),
 					}))
 				}
 			})
@@ -942,10 +945,13 @@ where
 
 					Ok(converted)
 				} else {
+					let span = token.span();
+					self.tokens.push(token);
+
 					Err(SpannedError {
 						message: format!("Expected {:?}", kind),
 						source: self.source(),
-						span: Some(token.span()),
+						span: Some(span),
 					})
 				}
 			})


### PR DESCRIPTION
Previously, the `consume_as` and `upgrade_last` implementations in `ParseStream` worked as follows:

* Pop the last token from the buffer
* Check the condition indicated by the function argument
  - If it passes:
    - Convert the token with the provided function
    - Push the converted token back onto the buffer
    - return an `Ok` with the converted token
  - Else:
    - return an `Err` indicating the condition failure

The fact that the `else` branch did _not_ push the original token back onto the buffer before returning would cause that token to be lost completely, which could cause unexpected issues if the user intended to handle the returned `Err`. This PR corrects that oversight by restoring the original token to the buffer before returning the `Err`.