### PR TITLE
`substr-source` feature and concrete `Lexer` implementation

### DIFF
--- a/benches/benches/lexer.rs
+++ b/benches/benches/lexer.rs
@@ -32,7 +32,7 @@ pub fn lexer(c: &mut Criterion) {
 	for (key, program) in programs {
 		let name = BenchmarkId::new("derived", key);
 		group.bench_with_input(name, program, move |b, input| {
-			b.iter_with_large_drop(|| lox::Lexer::new(input.into()).scan())
+			b.iter_with_large_drop(|| lox::TokenStream::new(input.into()).scan())
 		});
 
 		let name = BenchmarkId::new("manual", key);

--- a/crates/gramatika-macro/Cargo.toml
+++ b/crates/gramatika-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gramatika-macro"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["Danny McGee <dannymcgee@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/crates/gramatika-macro/src/lexer.rs
+++ b/crates/gramatika-macro/src/lexer.rs
@@ -19,7 +19,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 		use ::gramatika::Lexer as _;
 
 		#vis struct #lexer_ident {
-			input: ::gramatika::Substr,
+			input: ::gramatika::SourceStr,
 			remaining: ::gramatika::Substr,
 			current: ::gramatika::Position,
 			lookahead: ::gramatika::Position,
@@ -37,7 +37,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 		impl ::gramatika::Lexer for #lexer_ident {
 			type Output = #enum_ident;
 
-			fn new(input: ::gramatika::Substr) -> Self {
+			fn new(input: ::gramatika::SourceStr) -> Self {
 				Self {
 					remaining: input.substr(..),
 					input,
@@ -58,7 +58,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 				self
 			}
 
-			fn source(&self) -> ::gramatika::Substr {
+			fn source(&self) -> ::gramatika::SourceStr {
 				self.input.clone()
 			}
 

--- a/crates/gramatika-macro/src/lexer.rs
+++ b/crates/gramatika-macro/src/lexer.rs
@@ -19,7 +19,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 		use ::gramatika::Lexer as _;
 
 		#vis struct #lexer_ident {
-			input: ::gramatika::ArcStr,
+			input: ::gramatika::Substr,
 			remaining: ::gramatika::Substr,
 			current: ::gramatika::Position,
 			lookahead: ::gramatika::Position,
@@ -37,7 +37,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 		impl ::gramatika::Lexer for #lexer_ident {
 			type Output = #enum_ident;
 
-			fn new(input: ::gramatika::ArcStr) -> Self {
+			fn new(input: ::gramatika::Substr) -> Self {
 				Self {
 					remaining: input.substr(..),
 					input,
@@ -58,8 +58,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
 				self
 			}
 
-			fn source(&self) -> ::gramatika::ArcStr {
-				::gramatika::ArcStr::clone(&self.input)
+			fn source(&self) -> ::gramatika::Substr {
+				self.input.clone()
 			}
 
 			fn scan_token(&mut self) -> Option<Self::Output> {

--- a/crates/gramatika-macro/src/lib.rs
+++ b/crates/gramatika-macro/src/lib.rs
@@ -13,6 +13,7 @@ pub fn derive_token(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(Lexer)]
+#[deprecated(since = "0.6.0", note = "Use `gramatika::TokenStream<T>` instead")]
 pub fn derive_lexer(input: TokenStream) -> TokenStream {
 	lexer::derive(input)
 }

--- a/crates/gramatika-macro/tests/discard.rs
+++ b/crates/gramatika-macro/tests/discard.rs
@@ -7,7 +7,7 @@ extern crate gramatika;
 use gramatika::{Span, Substr};
 
 #[allow(dead_code)]
-#[derive(Debug, Token, Lexer)]
+#[derive(Debug, Token)]
 enum Token {
 	#[discard]
 	#[pattern = "//.*"]

--- a/crates/gramatika-macro/tests/lexer.rs
+++ b/crates/gramatika-macro/tests/lexer.rs
@@ -5,7 +5,7 @@ extern crate gramatika_macro;
 #[macro_use]
 extern crate gramatika;
 
-use gramatika::{Lexer as _, ParseStreamer, Span, Substr};
+use gramatika::{Lexer as _, ParseStreamer, Span, Substr, TokenStream};
 
 /// Expected output:
 ///
@@ -95,7 +95,7 @@ use gramatika::{Lexer as _, ParseStreamer, Span, Substr};
 
 // ...
 
-#[derive(Debug, Token, Lexer, PartialEq)]
+#[derive(Debug, Token, PartialEq)]
 enum Token {
 	#[subset_of(Ident)]
 	#[pattern = "let|var|if|for|while|return"]
@@ -112,24 +112,16 @@ enum Token {
 
 	#[pattern = "[0-9]+"]
 	Literal(Substr, Span),
-
-	OverrideTest(Substr, Span),
 }
 
 fn main() {
 	let input = "let foo = 2 + 2;";
-	let mut lexer = Lexer::new(input.into()).with_runtime_matcher(|s| {
-		if s.len() >= 3 && &s[..3] == "foo" {
-			Some((3, TokenKind::OverrideTest))
-		} else {
-			None
-		}
-	});
+	let mut lexer = TokenStream::<Token>::new(input.into());
 	let tokens = lexer.scan();
 
 	let expected = vec![
 		Token::keyword("let".into(), span![1:1..1:4]),
-		Token::override_test("foo".into(), span![1:5..1:8]),
+		Token::ident("foo".into(), span![1:5..1:8]),
 		Token::operator("=".into(), span![1:9..1:10]),
 		Token::literal("2".into(), span![1:11..1:12]),
 		Token::operator("+".into(), span![1:13..1:14]),

--- a/crates/gramatika-macro/tests/pattern.rs
+++ b/crates/gramatika-macro/tests/pattern.rs
@@ -7,7 +7,7 @@ extern crate gramatika;
 use gramatika::{Span, Substr};
 
 #[allow(dead_code)]
-#[derive(Debug, Token, Lexer)]
+#[derive(Debug, Token)]
 enum Token {
 	#[subset_of(Ident)]
 	#[pattern = "let|var|if|else|elsif|for|while|return"]

--- a/crates/gramatika/Cargo.toml
+++ b/crates/gramatika/Cargo.toml
@@ -25,3 +25,7 @@ macros = [
 	"once_cell",
 	"regex-automata",
 ]
+# Use `arcstr::Substr` instead of `arcstr::ArcStr` as the "source" type for
+# input text. This opens the possibility for some advanced use cases, like
+# using a different parser to process some portions of a text document.
+substr-source = []

--- a/crates/gramatika/Cargo.toml
+++ b/crates/gramatika/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gramatika"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 authors = ["Danny McGee <dannymcgee@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ once_cell = { version = "1.8", optional = true }
 regex-automata = { version = "0.1", optional = true }
 
 [dependencies.gramatika-macro]
-version = "0.5.1"
+version = "0.6.0"
 path = "../gramatika-macro"
 optional = true
 

--- a/crates/gramatika/src/error.rs
+++ b/crates/gramatika/src/error.rs
@@ -1,13 +1,11 @@
 use std::fmt;
 
-use arcstr::Substr;
-
-use crate::{DebugLisp, DebugLispStruct, Span};
+use crate::{DebugLisp, DebugLispStruct, SourceStr, Span};
 
 #[derive(Clone)]
 pub struct SpannedError {
 	pub message: String,
-	pub source: Substr,
+	pub source: SourceStr,
 	pub span: Option<Span>,
 }
 

--- a/crates/gramatika/src/error.rs
+++ b/crates/gramatika/src/error.rs
@@ -5,19 +5,17 @@ use arcstr::Substr;
 use crate::{DebugLisp, DebugLispStruct, Span};
 
 #[derive(Clone)]
-pub struct SpannedError<S> {
+pub struct SpannedError {
 	pub message: String,
-	pub source: S,
+	pub source: Substr,
 	pub span: Option<Span>,
 }
 
-pub type Result<T> = std::result::Result<T, SpannedError<Substr>>;
+pub type Result<T> = std::result::Result<T, SpannedError>;
 
-impl<S> std::error::Error for SpannedError<S> where S: AsRef<str> + fmt::Debug {}
+impl std::error::Error for SpannedError {}
 
-impl<S> fmt::Display for SpannedError<S>
-where S: AsRef<str>
-{
+impl fmt::Display for SpannedError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		if f.alternate() {
 			write!(f, "{}", self.message)
@@ -32,7 +30,6 @@ where S: AsRef<str>
 
 				let line = self
 					.source
-					.as_ref()
 					.lines()
 					.enumerate()
 					.find_map(|(idx, line)| {
@@ -65,9 +62,7 @@ where S: AsRef<str>
 	}
 }
 
-impl<D> fmt::Debug for SpannedError<D>
-where D: fmt::Debug
-{
+impl fmt::Debug for SpannedError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.debug_struct("SpannedError")
 			.field("message", &self.message)
@@ -77,7 +72,7 @@ where D: fmt::Debug
 	}
 }
 
-impl<S> DebugLisp for SpannedError<S> {
+impl DebugLisp for SpannedError {
 	fn fmt(&self, f: &mut fmt::Formatter, indent: usize) -> fmt::Result {
 		DebugLispStruct::new(f, indent, "SpannedError")
 			.field("message", &self.message)

--- a/crates/gramatika/src/lexer.rs
+++ b/crates/gramatika/src/lexer.rs
@@ -553,7 +553,7 @@ use std::{collections::HashSet, fmt, hash::Hash, marker::PhantomData};
 
 use arcstr::Substr;
 
-use crate::{Position, Span, Spanned};
+use crate::{Position, SourceStr, Span, Spanned};
 
 /// A lexer (AKA scanner, AKA tokenizer) is the piece of the parsing toolchain
 /// that takes raw input (e.g., the text of a source file) and "scans" it into
@@ -574,7 +574,7 @@ pub trait Lexer {
 	/// [`Output`] tokens.
 	///
 	/// [`Output`]: Lexer::Output
-	fn new(input: Substr) -> Self;
+	fn new(input: SourceStr) -> Self;
 
 	/// Experimental
 	#[doc(hidden)]
@@ -587,8 +587,8 @@ pub trait Lexer {
 		self
 	}
 
-	/// Returns an owned copy of the input [`Substr`] this lexer is scanning.
-	fn source(&self) -> Substr;
+	/// Returns an owned copy of the input [`SourceStr`] this lexer is scanning.
+	fn source(&self) -> SourceStr;
 
 	/// Scans a single token from the input.
 	///
@@ -620,7 +620,7 @@ pub trait Lexer {
 pub trait PartialLexer {
 	/// Initialize a new lexer from the state of some previous one that was
 	/// interrupted.
-	fn from_remaining(input: Substr, position: Position) -> Self;
+	fn from_remaining(input: SourceStr, position: Position) -> Self;
 
 	/// Consumes the lexer, returning the remaining (unscanned) portion of the
 	/// input and the current cursor position.
@@ -766,7 +766,7 @@ where Self: Clone + Spanned
 
 // TODO: Docs
 pub struct TokenStream<T> {
-	input: Substr,
+	input: SourceStr,
 	remaining: Substr,
 	current: Position,
 	lookahead: Position,
@@ -778,7 +778,7 @@ where T: Token
 {
 	type Output = T;
 
-	fn new(input: Substr) -> Self {
+	fn new(input: SourceStr) -> Self {
 		Self {
 			remaining: input.substr(..),
 			input,
@@ -788,7 +788,7 @@ where T: Token
 		}
 	}
 
-	fn source(&self) -> Substr {
+	fn source(&self) -> SourceStr {
 		self.input.clone()
 	}
 
@@ -868,9 +868,9 @@ where T: Token
 }
 
 impl<T> PartialLexer for TokenStream<T> {
-	fn from_remaining(input: Substr, position: Position) -> Self {
+	fn from_remaining(input: SourceStr, position: Position) -> Self {
 		Self {
-			remaining: input.clone(),
+			remaining: input.substr(..),
 			input,
 			current: position,
 			lookahead: position,

--- a/crates/gramatika/src/lexer.rs
+++ b/crates/gramatika/src/lexer.rs
@@ -1,6 +1,8 @@
-//! This module defines the [`Lexer`] and [`Token`] traits that lay the
-//! groundwork for parsing with Gramatika. In this documentation, we'll look at
-//! some less trivial `Token` examples and explore how the generated lexer
+//! This module defines the [`Lexer`], [`Token`], and [`TokenStream`] types that
+//! lay the groundwork for parsing with Gramatika.
+//!
+//! In this documentation, we'll look at some less trivial `Token` examples and
+//! explore how [`TokenStream`] --- the built-in [`Lexer`] implementation ---
 //! tokenizes input.
 //!
 //! ## Defining a token
@@ -14,7 +16,7 @@
 //! # fn main() {
 //! use gramatika::{Span, Substr};
 //!
-//! #[derive(Token, Lexer, PartialEq)]
+//! #[derive(Token, PartialEq)]
 //! enum Token {
 //! #    #[discard]
 //! #    #[pattern = "//.*"]
@@ -86,8 +88,8 @@
 //!   assert_eq!(printed, "1:1..1:5");
 //!   ```
 //!
-//! When the `Token` and [`Spanned`] traits are in scope, the lexeme and span
-//! can be extracted from a `Token` without needing to pattern-match. You can
+//! When the [`Token`] and [`Spanned`] traits are in scope, the lexeme and span
+//! can be extracted from a [`Token`] without needing to pattern-match. You can
 //! also grab them both in one go with the generated `as_inner` method.
 //!
 //! ```
@@ -126,7 +128,7 @@
 //! use core::fmt;
 //! use gramatika::{Span, Spanned, Substr, Token as _, span};
 //!
-//! #[derive(Token, Lexer, DebugLispToken, PartialEq)]
+//! #[derive(Token, DebugLispToken, PartialEq)]
 //! enum Token {
 //!     Ident(Substr, Span),
 //! }
@@ -154,10 +156,11 @@
 //! ```
 //! [`DebugLispToken`]: gramatika_macro::DebugLispToken
 //!
-//! ## Configuring the Lexer
+//! ## Configuring Tokenization
 //!
-//! The real power of Gramatika comes from its lexer generator. Let's define a
-//! pattern for our identifier token:
+//! The real power of Gramatika comes from its compile-time code generation.
+//! Let's define a pattern for our identifier token, and import the [`Lexer`]
+//! and [`TokenStream`] types:
 //!
 //! ```
 //! # #[macro_use]
@@ -165,10 +168,10 @@
 //! #
 //! # fn main() {
 //! # use core::fmt;
-//! # use gramatika::{Span, Spanned, Substr, Token as _, span};
+//! use gramatika::{Lexer, Span, Spanned, Substr, Token as _, TokenStream, span};
 //! #
 //! // ...
-//! #[derive(Token, Lexer, DebugLispToken, PartialEq)]
+//! #[derive(Token, DebugLispToken, PartialEq)]
 //! enum Token {
 //!     #[pattern = "[a-zA-Z_][a-zA-Z_0-9]*"]
 //!     Ident(Substr, Span),
@@ -192,7 +195,7 @@
 //!     loremIpsum
 //!     dolor_sit_amet
 //! ";
-//! let mut lexer = Lexer::new(input.into());
+//! let mut lexer = TokenStream::<Token>::new(input.into());
 //! let tokens = lexer.scan();
 //!
 //! assert_eq!(tokens.len(), 6);
@@ -202,8 +205,9 @@
 //! ```
 //!
 //! The `#[pattern]` attribute accepts the same syntax and features as the Rust
-//! [`regex` crate]. Those patterns are compiled to [deterministic finite automata]
-//!  and used by the generated lexer to find token matches in an input string.
+//! [`regex` crate]. Those patterns are compiled to static [deterministic finite
+//! automata] and used by the [`TokenStream`] to find token matches in an input
+//! string.
 //!
 //! [`regex` crate]: https://docs.rs/regex/latest/regex/
 //! [deterministic finite automata]: https://swtch.com/~rsc/regexp/regexp1.html
@@ -224,10 +228,10 @@
 //! #
 //! # fn main() {
 //! # use core::fmt;
-//! # use gramatika::{Span, Spanned, Substr, Token as _, span};
+//! # use gramatika::{Lexer, Span, Spanned, Substr, Token as _, span, TokenStream};
 //! #
 //! // ...
-//! #[derive(Token, Lexer, DebugLispToken, PartialEq)]
+//! #[derive(Token, DebugLispToken, PartialEq)]
 //! enum Token {
 //!     #[pattern = "[a-zA-Z_][a-zA-Z_0-9]*"]
 //!     Ident(Substr, Span),
@@ -249,7 +253,7 @@
 //! # }
 //!
 //! let input = "foo 42";
-//! let mut lexer = Lexer::new(input.into());
+//! let mut lexer = TokenStream::<Token>::new(input.into());
 //! let tokens = lexer.scan();
 //!
 //! assert_eq!(tokens.len(), 2);
@@ -273,10 +277,10 @@
 //! #
 //! # fn main() {
 //! # use core::fmt;
-//! # use gramatika::{Span, Spanned, Substr, Token as _, span};
+//! # use gramatika::{Lexer, Span, Spanned, Substr, Token as _, TokenStream, span};
 //! #
 //! // ...
-//! #[derive(Token, Lexer, DebugLispToken, PartialEq)]
+//! #[derive(Token, DebugLispToken, PartialEq)]
 //! enum Token {
 //!     #[discard]
 //!     #[pattern = "//.*"]
@@ -305,7 +309,7 @@
 //!     foo // Here's another one
 //! ";
 //!
-//! let mut lexer = Lexer::new(input.into());
+//! let mut lexer = TokenStream::<Token>::new(input.into());
 //! let tokens = lexer.scan();
 //!
 //! assert_eq!(tokens.len(), 1);
@@ -325,10 +329,10 @@
 //! #
 //! # fn main() {
 //! # use core::fmt;
-//! # use gramatika::{Span, Spanned, Substr, Token as _, span};
+//! # use gramatika::{Lexer, Span, Spanned, Substr, Token as _, TokenStream, span};
 //! #
 //! // ...
-//! #[derive(Token, Lexer, DebugLispToken, PartialEq)]
+//! #[derive(Token, DebugLispToken, PartialEq)]
 //! enum Token {
 //!     #[discard]
 //!     #[multiline]
@@ -365,7 +369,7 @@
 //!     foo // Here's a line comment
 //! ";
 //!
-//! let mut lexer = Lexer::new(input.into());
+//! let mut lexer = TokenStream::<Token>::new(input.into());
 //! let tokens = lexer.scan();
 //!
 //! assert_eq!(tokens.len(), 1);
@@ -385,10 +389,10 @@
 //! #
 //! # fn main() {
 //! # use core::fmt;
-//! # use gramatika::{Span, Spanned, Substr, Token as _, span};
+//! # use gramatika::{Lexer, Span, Spanned, Substr, Token as _, TokenStream, span};
 //! #
 //! // ...
-//! #[derive(Token, Lexer, DebugLispToken, PartialEq)]
+//! #[derive(Token, DebugLispToken, PartialEq)]
 //! enum Token {
 //!     #[pattern = "if|else|for|in|switch|case|break"]
 //!     Keyword(Substr, Span),
@@ -417,7 +421,7 @@
 //!         intent
 //! ";
 //!
-//! let mut lexer = Lexer::new(input.into());
+//! let mut lexer = TokenStream::<Token>::new(input.into());
 //! let tokens = lexer.scan();
 //!
 //! assert_eq!(tokens, vec![
@@ -442,10 +446,10 @@
 //! #
 //! # fn main() {
 //! # use core::fmt;
-//! # use gramatika::{Span, Spanned, Substr, Token as _, span};
+//! # use gramatika::{Lexer, Span, Spanned, Substr, Token as _, TokenStream, span};
 //! #
 //! // ...
-//! #[derive(Token, Lexer, DebugLispToken, PartialEq)]
+//! #[derive(Token, DebugLispToken, PartialEq)]
 //! enum Token {
 //!     #[subset_of(Ident)]
 //!     #[pattern = "if|else|for|in|switch|case|break"]
@@ -475,7 +479,7 @@
 //!         intent
 //! ";
 //!
-//! let mut lexer = Lexer::new(input.into());
+//! let mut lexer = TokenStream::<Token>::new(input.into());
 //! let tokens = lexer.scan();
 //!
 //! assert_eq!(tokens, vec![
@@ -502,10 +506,10 @@
 //! #
 //! # fn main() {
 //! # use core::fmt;
-//! # use gramatika::{Span, Spanned, Substr, Token as _, span};
+//! # use gramatika::{Lexer, Span, Spanned, Substr, Token as _, TokenStream, span};
 //! #
 //! // ...
-//! #[derive(Token, Lexer, DebugLispToken, PartialEq)]
+//! #[derive(Token, DebugLispToken, PartialEq)]
 //! enum Token {
 //!     #[pattern = r"[0-9]*\.[0-9]+"]
 //!     #[pattern = r"[0-9]+\.[0-9]*"]
@@ -533,7 +537,7 @@
 //!     50.
 //! ";
 //!
-//! let mut lexer = Lexer::new(input.into());
+//! let mut lexer = TokenStream::<Token>::new(input.into());
 //! let tokens = lexer.scan();
 //!
 //! assert_eq!(tokens, vec![
@@ -544,9 +548,9 @@
 //! # }
 //! ```
 //! The pattern above is exactly equivalent to `[0-9]*\.[0-9]+|[0-9]+\.[0-9]*`,
-//! but by putting them on separate lines we can more easily tell the difference
-//! between them (the first makes the digits _before_ the `.` optional, while
-//! the second does the same for digits _after_ the `.`).
+//! but by splitting the pattern into separate lines we can more easily tell the
+//! difference between the two alternations (the first makes the digits _before_
+//! the `.` optional, while the second does the same for digits _after_ the `.`).
 //!
 
 use std::{collections::HashSet, fmt, hash::Hash, marker::PhantomData};
@@ -614,7 +618,6 @@ pub trait Lexer {
 	}
 }
 
-// TODO
 /// Experimental
 #[doc(hidden)]
 pub trait PartialLexer {
@@ -647,17 +650,31 @@ where Self: Clone + Spanned
 {
 	type Kind: Copy + fmt::Debug + PartialEq + Eq + Hash + 'static;
 
-	// TODO: Docs
+	/// Find the first match for this token in a [`str`] slice, returning the
+	/// start and end byte offsets and the matching [`Kind`](Token::Kind).
 	fn find<S>(input: S) -> Option<(usize, usize, Self::Kind)>
 	where S: AsRef<str>;
 
-	// TODO: Docs
+	/// Construct a token from its constituent parts.
 	fn from_parts(kind: Self::Kind, substr: Substr, span: Span) -> Self;
 
-	// TODO: Docs
+	/// Returns the set of this token's variants which should be treated as
+	/// multi-line patterns (i.e., the `.` character in regex patterns should
+	/// match `\n` characters).
+	///
+	/// When using the [derive macro], returns the variants annotated with the
+	/// `#[multiline]` attribute.
+	///
+	/// [derive macro]: macro@crate::Token
 	fn multilines() -> &'static HashSet<Self::Kind>;
 
-	// TODO: Docs
+	/// Returns the set of this token's variants which should be discarded by the
+	/// lexer when scanning.
+	///
+	/// When using the [derive macro], returns the variants annotated with the
+	/// `#[discard]` attribute.
+	///
+	/// [derive macro]: macro@crate::Token
 	fn discards() -> &'static HashSet<Self::Kind>;
 
 	/// Returns the actual text content of a token.
@@ -668,11 +685,11 @@ where Self: Clone + Spanned
 	///
 	/// use gramatika::{
 	///     arcstr::literal_substr,
-	///     Substr, Span, Token as _,
+	///     Lexer, Substr, Span, Token as _, TokenStream,
 	/// };
 	///
 	/// # fn main() {
-	/// #[derive(Token, Lexer)]
+	/// #[derive(Token)]
 	/// enum Token {
 	///     #[subset_of(Ident)]
 	///     #[pattern = "var"]
@@ -692,7 +709,7 @@ where Self: Clone + Spanned
 	/// }
 	///
 	/// let src = "var the_answer = 42;";
-	/// let tokens = Lexer::new(src.into()).scan();
+	/// let tokens = TokenStream::<Token>::new(src.into()).scan();
 	///
 	/// assert_eq!(tokens[1].lexeme(), literal_substr!("the_answer"));
 	/// # }
@@ -712,17 +729,17 @@ where Self: Clone + Spanned
 	/// #[macro_use]
 	/// extern crate gramatika;
 	///
-	/// use gramatika::{Substr, Span, Token as _};
+	/// use gramatika::{Lexer, Substr, Span, Token as _, TokenStream};
 	///
 	/// # fn main() {
-	/// #[derive(Token, Lexer)]
+	/// #[derive(Token)]
 	/// enum Token {
 	///     #[pattern = "[a-zA-Z_][a-zA-Z0-9_]*"]
 	///     Ident(Substr, Span),
 	/// }
 	///
 	/// let input = "foo";
-	/// let token = Lexer::new(input.into())
+	/// let token = TokenStream::<Token>::new(input.into())
 	///     .scan_token()
 	///     .expect("Expected to match Ident `foo`");
 	///
@@ -744,17 +761,17 @@ where Self: Clone + Spanned
 	/// #[macro_use]
 	/// extern crate gramatika;
 	///
-	/// use gramatika::{Substr, Span, Token as _};
+	/// use gramatika::{Lexer, Substr, Span, Token as _, TokenStream};
 	///
 	/// # fn main() {
-	/// #[derive(Token, Lexer)]
+	/// #[derive(Token)]
 	/// enum Token {
 	///     #[pattern = "[a-zA-Z_][a-zA-Z0-9_]*"]
 	///     Ident(Substr, Span),
 	/// }
 	///
 	/// let input = "foo";
-	/// let token = Lexer::new(input.into())
+	/// let token = TokenStream::<Token>::new(input.into())
 	///     .scan_token()
 	///     .expect("Expected to match Ident `foo`");
 	///
@@ -764,7 +781,7 @@ where Self: Clone + Spanned
 	fn as_matchable(&self) -> (Self::Kind, &str, Span);
 }
 
-// TODO: Docs
+/// A concrete implementation of the [`Lexer`] interface.
 pub struct TokenStream<T> {
 	input: SourceStr,
 	remaining: Substr,

--- a/crates/gramatika/src/lexer.rs
+++ b/crates/gramatika/src/lexer.rs
@@ -551,7 +551,7 @@
 
 use std::fmt;
 
-use arcstr::{ArcStr, Substr};
+use arcstr::Substr;
 
 use crate::{Span, Spanned};
 
@@ -574,7 +574,7 @@ pub trait Lexer {
 	/// [`Output`] tokens.
 	///
 	/// [`Output`]: Lexer::Output
-	fn new(input: ArcStr) -> Self;
+	fn new(input: Substr) -> Self;
 
 	/// Experimental
 	#[doc(hidden)]
@@ -587,8 +587,8 @@ pub trait Lexer {
 		self
 	}
 
-	/// Returns an owned copy of the input [`ArcStr`] this lexer is scanning.
-	fn source(&self) -> ArcStr;
+	/// Returns an owned copy of the input [`Substr`] this lexer is scanning.
+	fn source(&self) -> Substr;
 
 	/// Scans a single token from the input.
 	///

--- a/crates/gramatika/src/lib.rs
+++ b/crates/gramatika/src/lib.rs
@@ -9,7 +9,7 @@
 //! gramatika = "0.5"
 //! ```
 //!
-//! Define an enum for your tokens and derive the `Token` and `Lexer` traits:
+//! Define an enum for your tokens and derive the [`Token`] trait:
 //! ```
 //! #[macro_use]
 //! extern crate gramatika;
@@ -17,7 +17,7 @@
 //! # fn main () {
 //! use gramatika::{Span, Substr};
 //!
-//! #[derive(Token, Lexer)]
+//! #[derive(Token)]
 //! enum Token {
 //!     #[pattern = "print"]
 //!     Keyword(Substr, Span),
@@ -35,7 +35,7 @@
 //! ```
 //!
 //! Next, you'll probably find it useful to declare a type alias for your
-//! [`ParseStream`]:
+//! [`TokenStream`] and [`ParseStream`]:
 //!
 //! ```
 //! # #[macro_use]
@@ -44,7 +44,7 @@
 //! # fn main () {
 //! # use gramatika::{Span, Substr};
 //! #
-//! # #[derive(Token, Lexer)]
+//! # #[derive(Token)]
 //! # enum Token {
 //! #     #[pattern = "print"]
 //! #     Keyword(Substr, Span),
@@ -56,6 +56,7 @@
 //! #     Unrecognized(Substr, Span),
 //! # }
 //! // ...
+//! type Lexer = gramatika::TokenStream<Token>;
 //! type ParseStream = gramatika::ParseStream<Token, Lexer>;
 //! # }
 //! ```
@@ -67,7 +68,7 @@
 //! # fn main () {
 //! # use gramatika::{Span, Substr};
 //! #
-//! # #[derive(Token, Lexer)]
+//! # #[derive(Token)]
 //! # enum Token {
 //! #     #[pattern = "print"]
 //! #     Keyword(Substr, Span),
@@ -78,6 +79,7 @@
 //! #     #[pattern = r"\S+"]
 //! #     Unrecognized(Substr, Span),
 //! # }
+//! # type Lexer = gramatika::TokenStream<Token>;
 //! # type ParseStream = gramatika::ParseStream<Token, Lexer>;
 //! // ...
 //! struct Program {
@@ -104,7 +106,7 @@
 //! # fn main () {
 //! use gramatika::{Parse, ParseStreamer, Span, SpannedError, Substr, Token as _};
 //!
-//! #[derive(Debug, Token, Lexer)]
+//! #[derive(Debug, Token)]
 //! enum Token {
 //!     // ...
 //! #     #[pattern = "print"]
@@ -116,6 +118,7 @@
 //! #     #[pattern = r"\S+"]
 //! #     Unrecognized(Substr, Span),
 //! }
+//! # type Lexer = gramatika::TokenStream<Token>;
 //! # type ParseStream = gramatika::ParseStream<Token, Lexer>;
 //! # struct Program {
 //! #    statements: Vec<Stmt>,
@@ -210,7 +213,7 @@
 //! use gramatika::{
 //!     Parse, ParseStreamer, Span, Spanned, SpannedError, Substr, Token as _,
 //! };
-//! # #[derive(Debug, Token, Lexer)]
+//! # #[derive(Debug, Token)]
 //! # enum Token {
 //! #     #[pattern = "print"]
 //! #     Keyword(Substr, Span),
@@ -221,6 +224,7 @@
 //! #     #[pattern = r"\S+"]
 //! #     Unrecognized(Substr, Span),
 //! # }
+//! # type Lexer = gramatika::TokenStream<Token>;
 //! # type ParseStream = gramatika::ParseStream<Token, Lexer>;
 //! #
 //! # struct Program {
@@ -309,7 +313,7 @@
 //! # use gramatika::{
 //! #     Parse, ParseStreamer, Span, Spanned, SpannedError, Substr, Token as _,
 //! # };
-//! # #[derive(Debug, Token, Lexer)]
+//! # #[derive(Debug, Token)]
 //! # enum Token {
 //! #     #[pattern = "print"]
 //! #     Keyword(Substr, Span),
@@ -320,6 +324,7 @@
 //! #     #[pattern = r"\S+"]
 //! #     Unrecognized(Substr, Span),
 //! # }
+//! # type Lexer = gramatika::TokenStream<Token>;
 //! # type ParseStream = gramatika::ParseStream<Token, Lexer>;
 //! #
 //! // ...
@@ -448,8 +453,12 @@ pub use span::*;
 
 pub use arcstr::{self, ArcStr, Substr};
 
+/// A type alias for [`arcstr::ArcStr`] (by default) or [`arcstr::Substr`] (if
+/// the `substr-source` feature is enabled).
 #[cfg(feature = "substr-source")]
 pub type SourceStr = Substr;
+/// A type alias for [`arcstr::ArcStr`] (by default) or [`arcstr::Substr`] (if
+/// the `substr-source` feature is enabled).
 #[cfg(not(feature = "substr-source"))]
 pub type SourceStr = ArcStr;
 

--- a/crates/gramatika/src/lib.rs
+++ b/crates/gramatika/src/lib.rs
@@ -448,6 +448,11 @@ pub use span::*;
 
 pub use arcstr::{self, ArcStr, Substr};
 
+#[cfg(feature = "substr-source")]
+pub type SourceStr = Substr;
+#[cfg(not(feature = "substr-source"))]
+pub type SourceStr = ArcStr;
+
 #[cfg(feature = "macros")]
 pub use gramatika_macro::*;
 

--- a/crates/gramatika/src/parse.rs
+++ b/crates/gramatika/src/parse.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use arcstr::{ArcStr, Substr};
+use arcstr::Substr;
 
 use crate::{Lexer, Position, Result, Span, Spanned, SpannedError, Token};
 
@@ -576,7 +576,7 @@ where
 	T: Token + Spanned,
 	L: Lexer<Output = T>,
 {
-	input: ArcStr,
+	input: Substr,
 	lexer: L,
 	peek: Option<T>,
 	tokens: Vec<T>,
@@ -596,11 +596,11 @@ where
 		}
 	}
 
-	pub fn source(&self) -> ArcStr {
-		ArcStr::clone(&self.input)
+	pub fn source(&self) -> Substr {
+		self.input.clone()
 	}
 
-	pub fn into_inner(self) -> (ArcStr, Vec<T>) {
+	pub fn into_inner(self) -> (Substr, Vec<T>) {
 		(self.input, self.tokens)
 	}
 
@@ -1013,13 +1013,13 @@ where
 
 impl<S, T, L> From<S> for ParseStream<T, L>
 where
-	S: Into<ArcStr>,
+	S: Into<Substr>,
 	T: Token + Spanned,
 	L: Lexer<Output = T>,
 {
 	fn from(input: S) -> Self {
 		let input = input.into();
-		let lexer = L::new(ArcStr::clone(&input));
+		let lexer = L::new(input.clone());
 
 		Self {
 			input,

--- a/crates/gramatika/src/parse.rs
+++ b/crates/gramatika/src/parse.rs
@@ -46,12 +46,12 @@ pub trait ParseStreamer {
 	/// #
 	/// # use gramatika::{
 	/// #     Parse, ParseStream, ParseStreamer,
-	/// #     Substr, Span, Token as _,
+	/// #     Substr, Span, Token as _, TokenStream,
 	/// # };
 	/// #
 	/// # fn main() -> gramatika::Result<()> {
 	/// // ...
-	/// #[derive(Token, Lexer, Debug)]
+	/// #[derive(Token, Debug)]
 	/// enum Token {
 	///     #[pattern = "[a-zA-Z_][a-zA-Z0-9_]*"]
 	///     Ident(Substr, Span),
@@ -62,7 +62,7 @@ pub trait ParseStreamer {
 	///
 	/// impl Parse for IdentExpr {
 	///     // ...
-	/// #     type Stream = ParseStream<Token, Lexer>;
+	/// #     type Stream = ParseStream<Token, TokenStream<Token>>;
 	/// #
 	/// #     fn parse(input: &mut Self::Stream) -> gramatika::Result<Self> {
 	/// #         Ok(Self(input.consume_kind(TokenKind::Ident)?))
@@ -95,20 +95,20 @@ pub trait ParseStreamer {
 	/// # extern crate gramatika;
 	/// #
 	/// # use gramatika::{
-	/// #     Parse, ParseStream, ParseStreamer,
-	/// #     Substr, Span, Token as _,
+	/// #     Lexer, Parse, ParseStream, ParseStreamer,
+	/// #     Substr, Span, Token as _, TokenStream,
 	/// # };
 	/// #
 	/// # fn main() -> gramatika::Result<()> {
 	/// // ...
-	/// #[derive(Token, Lexer, Debug)]
+	/// #[derive(Token, Debug)]
 	/// enum Token {
 	///     #[pattern = "[a-zA-Z_][a-zA-Z0-9_]*"]
 	///     Ident(Substr, Span),
 	/// }
 	///
 	/// let input = "foo";
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::<Token, TokenStream<Token>>::from(input);
 	/// assert!(parser.peek().is_some());
 	///
 	/// match parser.peek() {
@@ -139,20 +139,20 @@ pub trait ParseStreamer {
 	/// # extern crate gramatika;
 	/// #
 	/// # use gramatika::{
-	/// #     Parse, ParseStream, ParseStreamer,
-	/// #     Substr, Span, Token as _,
+	/// #     Lexer, Parse, ParseStream, ParseStreamer,
+	/// #     Substr, Span, Token as _, TokenStream,
 	/// # };
 	/// #
 	/// # fn main() -> gramatika::Result<()> {
 	/// // ...
-	/// #[derive(Token, Lexer, Debug, PartialEq)]
+	/// #[derive(Token, Debug, PartialEq)]
 	/// enum Token {
 	///     #[pattern = "[a-zA-Z_][a-zA-Z0-9_]*"]
 	///     Ident(Substr, Span),
 	/// }
 	///
 	/// let input = "foo";
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::<Token, TokenStream<Token>>::from(input);
 	/// assert!(parser.prev().is_none());
 	///
 	/// let foo = parser.consume_kind(TokenKind::Ident)?;
@@ -174,13 +174,13 @@ pub trait ParseStreamer {
 	/// # extern crate gramatika;
 	/// #
 	/// # use gramatika::{
-	/// #     Parse, ParseStream, ParseStreamer,
-	/// #     Substr, Span, Token as _,
+	/// #     Lexer, Parse, ParseStream, ParseStreamer,
+	/// #     Substr, Span, Token as _, TokenStream,
 	/// # };
 	/// #
 	/// # fn main() -> gramatika::Result<()> {
 	/// // ...
-	/// #[derive(Token, Lexer, Debug, PartialEq)]
+	/// #[derive(Token, Debug, PartialEq)]
 	/// enum Token {
 	///     #[pattern = "[a-zA-Z_][a-zA-Z0-9_]*"]
 	///     Ident(Substr, Span),
@@ -189,7 +189,7 @@ pub trait ParseStreamer {
 	/// }
 	///
 	/// let input = "foo";
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::<Token, TokenStream<Token>>::from(input);
 	/// assert_eq!(
 	///     parser.check_kind(TokenKind::Unrecognized),
 	///     false,
@@ -216,20 +216,20 @@ pub trait ParseStreamer {
 	/// # extern crate gramatika;
 	/// #
 	/// # use gramatika::{
-	/// #     Parse, ParseStream, ParseStreamer,
-	/// #     Substr, Span, Token as _,
+	/// #     Lexer, Parse, ParseStream, ParseStreamer,
+	/// #     Substr, Span, Token as _, TokenStream,
 	/// # };
 	/// #
 	/// # fn main() -> gramatika::Result<()> {
 	/// // ...
-	/// #[derive(Token, Lexer, Debug, PartialEq)]
+	/// #[derive(Token, Debug, PartialEq)]
 	/// enum Token {
 	///     #[pattern = "[-+*/=<>]"]
 	///     Operator(Substr, Span),
 	/// }
 	///
 	/// let input = "=";
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::<Token, TokenStream<Token>>::from(input);
 	/// assert_eq!(
 	///     parser.check(operator![>]),
 	///     false,
@@ -256,20 +256,20 @@ pub trait ParseStreamer {
 	/// # extern crate gramatika;
 	/// #
 	/// # use gramatika::{
-	/// #     Parse, ParseStream, ParseStreamer,
-	/// #     Substr, Span, Token as _,
+	/// #     Lexer, Parse, ParseStream, ParseStreamer,
+	/// #     Substr, Span, Token as _, TokenStream,
 	/// # };
 	/// #
 	/// # fn main() -> gramatika::Result<()> {
 	/// // ...
-	/// #[derive(Token, Lexer, Debug, PartialEq)]
+	/// #[derive(Token, Debug, PartialEq)]
 	/// enum Token {
 	///     #[pattern = "[-+*/=<>]"]
 	///     Operator(Substr, Span),
 	/// }
 	///
 	/// let input = "=<";
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::<Token, TokenStream<Token>>::from(input);
 	///
 	/// let eq = parser.consume(operator![=]);
 	/// assert!(eq.is_ok());
@@ -301,13 +301,13 @@ pub trait ParseStreamer {
 	/// # extern crate gramatika;
 	/// #
 	/// # use gramatika::{
-	/// #     Parse, ParseStream, ParseStreamer,
-	/// #     Substr, Span, Token as _,
+	/// #     Lexer, Parse, ParseStream, ParseStreamer,
+	/// #     Substr, Span, Token as _, TokenStream,
 	/// # };
 	/// #
 	/// # fn main() -> gramatika::Result<()> {
 	/// // ...
-	/// #[derive(Token, Lexer, Debug, PartialEq)]
+	/// #[derive(Token, Debug, PartialEq)]
 	/// enum Token {
 	///     #[pattern = "[-+*/<>]"]
 	///     Operator(Substr, Span),
@@ -317,7 +317,7 @@ pub trait ParseStreamer {
 	/// }
 	///
 	/// let input = "2++";
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::<Token, TokenStream<Token>>::from(input);
 	///
 	/// let lhs = parser.consume_kind(TokenKind::Number);
 	/// assert!(lhs.is_ok());
@@ -357,14 +357,14 @@ pub trait ParseStreamer {
 	/// # extern crate gramatika;
 	/// #
 	/// # use gramatika::{
-	/// #     Parse, ParseStream, ParseStreamer,
+	/// #     Lexer, Parse, ParseStream, ParseStreamer,
 	/// #     Substr, Span, Token as _,
-	/// #     SpannedError,
+	/// #     SpannedError, TokenStream,
 	/// # };
 	/// #
 	/// # fn main() -> gramatika::Result<()> {
 	/// // ...
-	/// #[derive(Token, Lexer, Debug, PartialEq)]
+	/// #[derive(Token, Debug, PartialEq)]
 	/// enum Token {
 	///     #[subset_of(Ident)]
 	///     #[pattern = "func|struct"]
@@ -385,7 +385,7 @@ pub trait ParseStreamer {
 	///     func bar() {}
 	/// "#;
 	///
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::<Token, TokenStream<Token>>::from(input);
 	///
 	/// while let Some(token) = parser.next() {
 	///     use TokenKind::*;
@@ -436,14 +436,14 @@ pub trait ParseStreamer {
 	/// # extern crate gramatika;
 	/// #
 	/// # use gramatika::{
-	/// #     Parse, ParseStream, ParseStreamer,
+	/// #     Lexer, Parse, ParseStream, ParseStreamer,
 	/// #     Substr, Span, Token as _,
-	/// #     SpannedError,
+	/// #     SpannedError, TokenStream,
 	/// # };
 	/// #
 	/// # fn main() -> gramatika::Result<()> {
 	/// // ...
-	/// #[derive(Token, Lexer, Debug, PartialEq)]
+	/// #[derive(Token, Debug, PartialEq)]
 	/// enum Token {
 	///     #[pattern = "[a-zA-Z_][a-zA-Z0-9_]*"]
 	///     Ident(Substr, Span),
@@ -459,7 +459,7 @@ pub trait ParseStreamer {
 	///
 	/// let input = "foo = bar()";
 	///
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::<Token, TokenStream<Token>>::from(input);
 	///
 	/// let lhs = parser.consume_kind(TokenKind::Ident)?;
 	/// let eq = parser.consume(eq![=])?;
@@ -505,14 +505,14 @@ pub trait ParseStreamer {
 	/// # extern crate gramatika;
 	/// #
 	/// # use gramatika::{
-	/// #     Parse, ParseStream, ParseStreamer,
+	/// #     Lexer, Parse, ParseStream, ParseStreamer,
 	/// #     Substr, Span, Token as _,
-	/// #     SpannedError,
+	/// #     SpannedError, TokenStream,
 	/// # };
 	/// #
 	/// # fn main() -> gramatika::Result<()> {
 	/// // ...
-	/// #[derive(Token, Lexer, Debug, PartialEq)]
+	/// #[derive(Token, Debug, PartialEq)]
 	/// enum Token {
 	///     #[pattern = "[a-zA-Z_][a-zA-Z0-9_]*"]
 	///     Ident(Substr, Span),
@@ -528,7 +528,7 @@ pub trait ParseStreamer {
 	///
 	/// let input = "foo = bar()";
 	///
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::<Token, TokenStream<Token>>::from(input);
 	///
 	/// let lhs = parser.consume_kind(TokenKind::Ident)?;
 	/// let eq = parser.consume(eq![=])?;
@@ -559,17 +559,18 @@ pub trait ParseStreamer {
 /// A concrete implementation of the [`ParseStreamer`] interface.
 ///
 /// For most applications, it should be sufficient to use this type as the
-/// "engine" for your parser, by deriving [`Token`] and [`Lexer`] for an enum
-/// type representing your language's tokens[^note], and using
-/// `ParseStream<T, L>` as the [`Stream`] type for your syntax tree's [`Parse`]
-/// implementations, where `T` is your concrete token type and `L` is your
-/// generated lexer.
+/// "engine" for your parser, by deriving [`Token`] for an enum type
+/// representing your language's tokens, and using `ParseStream<T, L>` as the
+/// [`Stream`] type for your syntax tree's [`Parse`] implementations, where `T`
+/// is your concrete token type and `L` is either the built-in [`TokenStream`]
+/// type or a custom [`Lexer`] implementation.
 ///
 /// See the [crate-level documentation] and the [`lexer`](crate::lexer)
 /// documentation for examples and (much) more detail, and see the
 /// [`ParseStreamer`] documentation for an overview of this type's public API.
 ///
 /// [`Stream`]: Parse::Stream
+/// [`TokenStream`]: crate::lexer::TokenStream
 /// [crate-level documentation]: crate
 pub struct ParseStream<T, L>
 where
@@ -616,9 +617,9 @@ where
 	/// ```
 	/// # #[macro_use] extern crate gramatika_macro;
 	/// # fn main () {
-	/// use gramatika::{span, Substr, Span, ParseStream, ParseStreamer};
+	/// use gramatika::{span, Lexer, Substr, Span, ParseStream, ParseStreamer, TokenStream};
 	///
-	/// #[derive(Token, Lexer, Debug, PartialEq, Eq)]
+	/// #[derive(Token, Debug, PartialEq, Eq)]
 	/// enum Token {
 	///     #[pattern = "ab"]
 	///     Ab(Substr, Span),
@@ -629,7 +630,7 @@ where
 	/// }
 	///
 	/// let input = "ab";
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::<Token, TokenStream<Token>>::from(input);
 	///
 	/// assert_eq!(parser.peek(), Some(&Token::Ab("ab".into(), span![1:1..1:3])));
 	///
@@ -649,9 +650,11 @@ where
 	/// ```
 	/// # #[macro_use] extern crate gramatika_macro;
 	/// # fn main () {
-	/// use gramatika::{Result, Parse, ParseStream, ParseStreamer, Span, Substr};
+	/// use gramatika::{
+	///     Lexer, Result, Parse, ParseStreamer, Span, Substr, TokenStream,
+	/// };
 	///
-	/// #[derive(Token, Lexer, Debug, PartialEq, Eq)]
+	/// #[derive(Token, Debug, PartialEq, Eq)]
 	/// enum Token {
 	///     #[pattern = "[a-zA-Z_][a-zA-Z0-9_]*"]
 	///     Ident(Substr, Span),
@@ -661,6 +664,8 @@ where
 	///     #[pattern = "[%*/~^]"]
 	///     Operator(Substr, Span),
 	/// }
+	///
+	/// type ParseStream = gramatika::ParseStream<Token, TokenStream<Token>>;
 	///
 	/// #[derive(Debug)]
 	/// struct Good {
@@ -675,7 +680,7 @@ where
 	/// }
 	///
 	/// impl Parse for Bad {
-	///     type Stream = ParseStream<Token, Lexer>;
+	///     type Stream = ParseStream;
 	///
 	///     fn parse(input: &mut Self::Stream) -> Result<Self> {
 	///         let mut result = Bad {
@@ -694,7 +699,7 @@ where
 	/// }
 	///
 	/// impl Parse for Good {
-	///     type Stream = ParseStream<Token, Lexer>;
+	///     type Stream = ParseStream;
 	///
 	///     fn parse(input: &mut Self::Stream) -> Result<Self> {
 	///         let mut result = Good {
@@ -719,7 +724,7 @@ where
 	///
 	/// let input = "Foo<Bar<Baz>>";
 	///
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::from(input);
 	/// let bad = parser.parse::<Bad>();
 	/// assert!(bad.is_err());
 	///
@@ -732,7 +737,7 @@ where
 	///   |            ^-
 	/// ");
 	///
-	/// let mut parser = ParseStream::<Token, Lexer>::from(input);
+	/// let mut parser = ParseStream::from(input);
 	/// let good = parser.parse::<Good>();
 	/// assert!(good.is_ok());
 	/// # }

--- a/crates/gramatika/src/parse.rs
+++ b/crates/gramatika/src/parse.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use arcstr::Substr;
 
-use crate::{Lexer, Position, Result, Span, Spanned, SpannedError, Token};
+use crate::{Lexer, Position, Result, SourceStr, Span, Spanned, SpannedError, Token};
 
 pub type TokenCtor<T> = fn(Substr, Span) -> T;
 
@@ -576,7 +576,7 @@ where
 	T: Token + Spanned,
 	L: Lexer<Output = T>,
 {
-	input: Substr,
+	input: SourceStr,
 	lexer: L,
 	peek: Option<T>,
 	tokens: Vec<T>,
@@ -596,11 +596,11 @@ where
 		}
 	}
 
-	pub fn source(&self) -> Substr {
+	pub fn source(&self) -> SourceStr {
 		self.input.clone()
 	}
 
-	pub fn into_inner(self) -> (Substr, Vec<T>) {
+	pub fn into_inner(self) -> (SourceStr, Vec<T>) {
 		(self.input, self.tokens)
 	}
 
@@ -1013,7 +1013,7 @@ where
 
 impl<S, T, L> From<S> for ParseStream<T, L>
 where
-	S: Into<Substr>,
+	S: Into<SourceStr>,
 	T: Token + Spanned,
 	L: Lexer<Output = T>,
 {

--- a/examples/lox/src/lib.rs
+++ b/examples/lox/src/lib.rs
@@ -10,12 +10,13 @@ mod stmt;
 mod tokens;
 
 use stmt::Program;
-pub use tokens::Lexer;
+// pub use tokens::Lexer;
 use tokens::Token;
 
 use gramatika::ParseStreamer;
 
-type ParseStream = gramatika::ParseStream<Token, Lexer>;
+pub type TokenStream = gramatika::TokenStream<Token>;
+type ParseStream = gramatika::ParseStream<Token, TokenStream>;
 
 pub fn parse(input: String) -> gramatika::Result<Program> {
 	ParseStream::from(input).parse()

--- a/examples/lox/src/tests/lexer.rs
+++ b/examples/lox/src/tests/lexer.rs
@@ -1,12 +1,12 @@
 use crate::{tokens::Token, TokenStream};
-use gramatika::{arcstr::literal_substr, Lexer as _, Substr};
+use gramatika::{arcstr::literal_substr, Lexer as _};
 
 #[test]
 fn it_works() {
 	use Token::*;
 
 	let input = "var foo = 2 + 2;";
-	let mut lexer = TokenStream::new(Substr::from(input));
+	let mut lexer = TokenStream::new(input.into());
 	let tokens = lexer.scan();
 
 	let expected = vec![
@@ -30,7 +30,7 @@ fn multi_line() {
 var foo = 2 + 2;
 var bar = foo + foo;
 	";
-	let mut lexer = TokenStream::new(Substr::from(input));
+	let mut lexer = TokenStream::new(input.into());
 	let tokens = lexer.scan();
 
 	let expected = vec![
@@ -83,7 +83,7 @@ var foo = 2 + 2;
 #[test]
 fn ident_with_digit() {
 	let input = "foo2";
-	let mut lexer = TokenStream::new(Substr::from(input));
+	let mut lexer = TokenStream::new(input.into());
 	let tokens = lexer.scan();
 
 	assert_eq!(

--- a/examples/lox/src/tests/lexer.rs
+++ b/examples/lox/src/tests/lexer.rs
@@ -1,4 +1,4 @@
-use crate::{tokens::Token, Lexer};
+use crate::{tokens::Token, TokenStream};
 use gramatika::{arcstr::literal_substr, Lexer as _, Substr};
 
 #[test]
@@ -6,7 +6,7 @@ fn it_works() {
 	use Token::*;
 
 	let input = "var foo = 2 + 2;";
-	let mut lexer = Lexer::new(Substr::from(input));
+	let mut lexer = TokenStream::new(Substr::from(input));
 	let tokens = lexer.scan();
 
 	let expected = vec![
@@ -30,7 +30,7 @@ fn multi_line() {
 var foo = 2 + 2;
 var bar = foo + foo;
 	";
-	let mut lexer = Lexer::new(Substr::from(input));
+	let mut lexer = TokenStream::new(Substr::from(input));
 	let tokens = lexer.scan();
 
 	let expected = vec![
@@ -64,7 +64,7 @@ fn multi_line_token() {
  */
 var foo = 2 + 2;
 	";
-	let mut lexer = Lexer::new(input.into());
+	let mut lexer = TokenStream::new(input.into());
 	let tokens = lexer.scan();
 
 	let expected = vec![
@@ -83,7 +83,7 @@ var foo = 2 + 2;
 #[test]
 fn ident_with_digit() {
 	let input = "foo2";
-	let mut lexer = Lexer::new(Substr::from(input));
+	let mut lexer = TokenStream::new(Substr::from(input));
 	let tokens = lexer.scan();
 
 	assert_eq!(

--- a/examples/lox/src/tests/lexer.rs
+++ b/examples/lox/src/tests/lexer.rs
@@ -1,12 +1,12 @@
 use crate::{tokens::Token, Lexer};
-use gramatika::{arcstr::literal_substr, ArcStr, Lexer as _};
+use gramatika::{arcstr::literal_substr, Lexer as _, Substr};
 
 #[test]
 fn it_works() {
 	use Token::*;
 
 	let input = "var foo = 2 + 2;";
-	let mut lexer = Lexer::new(ArcStr::from(input));
+	let mut lexer = Lexer::new(Substr::from(input));
 	let tokens = lexer.scan();
 
 	let expected = vec![
@@ -30,7 +30,7 @@ fn multi_line() {
 var foo = 2 + 2;
 var bar = foo + foo;
 	";
-	let mut lexer = Lexer::new(ArcStr::from(input));
+	let mut lexer = Lexer::new(Substr::from(input));
 	let tokens = lexer.scan();
 
 	let expected = vec![
@@ -83,7 +83,7 @@ var foo = 2 + 2;
 #[test]
 fn ident_with_digit() {
 	let input = "foo2";
-	let mut lexer = Lexer::new(ArcStr::from(input));
+	let mut lexer = Lexer::new(Substr::from(input));
 	let tokens = lexer.scan();
 
 	assert_eq!(

--- a/examples/lox/src/tokens.rs
+++ b/examples/lox/src/tokens.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use gramatika::{DebugLisp, Span, Substr, Token as _};
 
-#[derive(DebugLispToken, PartialEq, Token, Lexer)]
+#[derive(DebugLispToken, PartialEq, Token)]
 pub enum Token {
 	#[discard]
 	#[pattern = "//.*"]

--- a/examples/lox_manual_impl/src/lexer.rs
+++ b/examples/lox_manual_impl/src/lexer.rs
@@ -1,5 +1,5 @@
 use arcstr::Substr;
-use gramatika::{Position, Span};
+use gramatika::{Position, Span, Token as _};
 
 use crate::tokens::{Token, TokenKind};
 
@@ -64,7 +64,7 @@ impl gramatika::Lexer for Lexer {
 				};
 				let lexeme = self.remaining.substr(start..end);
 
-				if TokenKind::multilines().contains(&kind) {
+				if Token::multilines().contains(&kind) {
 					let mut line_inc = 0_usize;
 					let mut remaining = lexeme.as_str();
 
@@ -94,7 +94,7 @@ impl gramatika::Lexer for Lexer {
 				self.remaining = self.remaining.substr(end..);
 				self.current = self.lookahead;
 
-				if TokenKind::discards().contains(&kind) {
+				if Token::discards().contains(&kind) {
 					self.scan_token()
 				} else {
 					Some(token)

--- a/examples/lox_manual_impl/src/lexer.rs
+++ b/examples/lox_manual_impl/src/lexer.rs
@@ -1,10 +1,10 @@
-use arcstr::{ArcStr, Substr};
+use arcstr::Substr;
 use gramatika::{Position, Span};
 
 use crate::tokens::{Token, TokenKind};
 
 pub struct Lexer {
-	input: ArcStr,
+	input: Substr,
 	remaining: Substr,
 	current: Position,
 	lookahead: Position,
@@ -15,7 +15,7 @@ type TokenCtor = fn(lexeme: Substr, span: Span) -> Token;
 impl gramatika::Lexer for Lexer {
 	type Output = Token;
 
-	fn new(input: ArcStr) -> Self {
+	fn new(input: Substr) -> Self {
 		Self {
 			remaining: input.substr(..),
 			input,
@@ -24,7 +24,7 @@ impl gramatika::Lexer for Lexer {
 		}
 	}
 
-	fn source(&self) -> ArcStr {
+	fn source(&self) -> Substr {
 		self.input.clone()
 	}
 

--- a/examples/lox_manual_impl/src/lexer.rs
+++ b/examples/lox_manual_impl/src/lexer.rs
@@ -1,10 +1,10 @@
 use arcstr::Substr;
-use gramatika::{Position, Span, Token as _};
+use gramatika::{Position, SourceStr, Span, Token as _};
 
 use crate::tokens::{Token, TokenKind};
 
 pub struct Lexer {
-	input: Substr,
+	input: SourceStr,
 	remaining: Substr,
 	current: Position,
 	lookahead: Position,
@@ -15,7 +15,7 @@ type TokenCtor = fn(lexeme: Substr, span: Span) -> Token;
 impl gramatika::Lexer for Lexer {
 	type Output = Token;
 
-	fn new(input: Substr) -> Self {
+	fn new(input: SourceStr) -> Self {
 		Self {
 			remaining: input.substr(..),
 			input,
@@ -24,7 +24,7 @@ impl gramatika::Lexer for Lexer {
 		}
 	}
 
-	fn source(&self) -> Substr {
+	fn source(&self) -> SourceStr {
 		self.input.clone()
 	}
 

--- a/examples/lox_manual_impl/src/parse.rs
+++ b/examples/lox_manual_impl/src/parse.rs
@@ -1,4 +1,4 @@
-use arcstr::ArcStr;
+use arcstr::Substr;
 use gramatika::{
 	Lexer as _, ParseStreamer, Result, Spanned, SpannedError, Token as _, TokenCtor,
 };
@@ -9,7 +9,7 @@ use crate::{
 };
 
 pub struct ParseStream {
-	input: ArcStr,
+	input: Substr,
 	lexer: Lexer,
 	peek: Option<Token>,
 	tokens: Vec<Token>,
@@ -25,11 +25,11 @@ impl ParseStream {
 		}
 	}
 
-	pub fn source(&self) -> ArcStr {
-		ArcStr::clone(&self.input)
+	pub fn source(&self) -> Substr {
+		self.input.clone()
 	}
 
-	pub fn into_inner(self) -> (ArcStr, Vec<Token>) {
+	pub fn into_inner(self) -> (Substr, Vec<Token>) {
 		(self.input, self.tokens)
 	}
 
@@ -226,11 +226,11 @@ impl From<Lexer> for ParseStream {
 }
 
 impl<S> From<S> for ParseStream
-where S: Into<ArcStr>
+where S: Into<Substr>
 {
 	fn from(input: S) -> Self {
 		let input = input.into();
-		let lexer = Lexer::new(ArcStr::clone(&input));
+		let lexer = Lexer::new(input.clone());
 
 		Self {
 			input,

--- a/examples/lox_manual_impl/src/parse.rs
+++ b/examples/lox_manual_impl/src/parse.rs
@@ -1,6 +1,6 @@
-use arcstr::Substr;
 use gramatika::{
-	Lexer as _, ParseStreamer, Result, Spanned, SpannedError, Token as _, TokenCtor,
+	Lexer as _, ParseStreamer, Result, SourceStr, Spanned, SpannedError, Token as _,
+	TokenCtor,
 };
 
 use crate::{
@@ -9,7 +9,7 @@ use crate::{
 };
 
 pub struct ParseStream {
-	input: Substr,
+	input: SourceStr,
 	lexer: Lexer,
 	peek: Option<Token>,
 	tokens: Vec<Token>,
@@ -25,11 +25,11 @@ impl ParseStream {
 		}
 	}
 
-	pub fn source(&self) -> Substr {
+	pub fn source(&self) -> SourceStr {
 		self.input.clone()
 	}
 
-	pub fn into_inner(self) -> (Substr, Vec<Token>) {
+	pub fn into_inner(self) -> (SourceStr, Vec<Token>) {
 		(self.input, self.tokens)
 	}
 
@@ -226,7 +226,7 @@ impl From<Lexer> for ParseStream {
 }
 
 impl<S> From<S> for ParseStream
-where S: Into<Substr>
+where S: Into<SourceStr>
 {
 	fn from(input: S) -> Self {
 		let input = input.into();


### PR DESCRIPTION
## New Cargo feature: `substr-source`

When enabled, this replaces `arcstr::ArcStr` with `arcstr::Substr` for all fields and methods that represent the original source text of a document being scanned or parsed. A root-level `SourceStr` type alias has also been added to make it easier to refer to this type regardless of whether the feature is enabled or not.

This feature enables optimizations for some niche advanced use cases that are currently being explored in [`wgsl_parser`]. Namely, this allows a completely different lexer/parser combinations to operate on subsets of a document, without needing to allocate a new `ArcStr` for each subset.

In the future, this could be leveraged to extend Gramatika's utility to languages like XML that require a stateful, context-sensitive lexer that exhibits different scanning behavior depending on its current state, but that would require some additional effort and API design which is out of scope for this particular update.

[`wgsl_parser`]: https://crates.io/crates/wgsl_parser

## Concrete `Lexer` implementation and deprecation of `#[derive(Lexer)]`

Additionally, this update deprecates the `Lexer` derive macro, replacing it with a new concrete `TokenStream` type provided by the crate. This follows the same convention used by the `parse` module, where the `ParseStream` type is provided as an optional, concrete implementation of the `ParseStreamer` trait.

The `Lexer` derive was often a bit awkward to use (and extremely unhygienic), because it emitted a phantom `struct Lexer` type which couldn't be directly inspected, renamed, or otherwise modified by the user.

To migrate, simply remove the `#[derive(Lexer)]` attribute from your token type, and replace all references to the previously generated `Lexer` struct with `gramatika::TokenStream<T>`, where `T` is your token type.