### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/crates/gramatika-macro/Cargo.toml
+++ b/crates/gramatika-macro/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Danny McGee <dannymcgee@gmail.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../../README.md"
-repository = "http://github.com/dannymcgee/gramatika"
+repository = "https://github.com/dannymcgee/gramatika"
 description = "Proc macros for Gramatika"
 
 [lib]


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97